### PR TITLE
TC-UI-006: Implement custom sidebar navigation to replace default page order

### DIFF
--- a/app/.streamlit/config.toml
+++ b/app/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[client]
+showSidebarNavigation = false

--- a/app/Home.py
+++ b/app/Home.py
@@ -1,14 +1,36 @@
 import streamlit as st
 
-st.set_page_config(page_title="Transcript Coder", layout="wide")
+# Page configuration
+st.set_page_config(
+    page_title="Transcript Coder",
+    page_icon="🎯",
+    layout="wide",
+    initial_sidebar_state="expanded"
+)
 
+# Sidebar navigation
+with st.sidebar:
+    st.page_link("Home.py", label="🏠 Home")
+    st.page_link("pages/Dictionary.py", label="📚 Dictionary")
+    st.page_link("pages/Upload.py", label="📤 Upload")
+    st.page_link("pages/Reports.py", label="📊 Reports")
+
+# Main page content
 st.title("🎯 Welcome to Transcript Coder")
 
-st.markdown("Effortlessly upload, code, and analyze your transcripts.")
+st.markdown("""
+Effortlessly upload, code, and analyze your transcripts with ease.  
+""")
 
 st.divider()
 
-st.subheader("🚀 Get Started:")
-st.write("Use the sidebar to navigate to Upload, Dictionary, or Reports.")
+st.subheader("🚀 Get Started")
+st.markdown("""
+- **Dictionary**: View or update the coding dictionary.
+- **Upload**: Import your transcript CSV files.
+- **Reports**: Analyze your coded transcripts and download reports.
+""")
 
-st.caption("Built with ❤️ using Streamlit")
+st.divider()
+
+st.caption("Built with ❤️ using Streamlit | CITS5206 Group 3")

--- a/app/pages/Dictionary.py
+++ b/app/pages/Dictionary.py
@@ -3,6 +3,12 @@ st.set_page_config(page_title="Manage Coding Dictionary", layout="wide")
 import pandas as pd
 import os
 
+# Sidebar navigation
+st.sidebar.page_link("Home.py", label="🏠 Home")
+st.sidebar.page_link("pages/Dictionary.py", label="📚 Dictionary")
+st.sidebar.page_link("pages/Upload.py", label="📤 Upload")
+st.sidebar.page_link("pages/Reports.py", label="📊 Reports")
+
 st.title("📚 Manage Coding Dictionary")
 
 # Setup dictionary saving

--- a/app/pages/Reports.py
+++ b/app/pages/Reports.py
@@ -1,6 +1,12 @@
 import streamlit as st
 st.set_page_config(page_title="Reports and Analysis", layout="wide")
 
+# Sidebar navigation
+st.sidebar.page_link("Home.py", label="🏠 Home")
+st.sidebar.page_link("pages/Dictionary.py", label="📚 Dictionary")
+st.sidebar.page_link("pages/Upload.py", label="📤 Upload")
+st.sidebar.page_link("pages/Reports.py", label="📊 Reports")
+
 st.title("📊 Reports and Analysis")
 
 st.write("View coded results, summaries, and download reports here.")

--- a/app/pages/Upload.py
+++ b/app/pages/Upload.py
@@ -4,6 +4,13 @@ import pandas as pd
 import tempfile
 import os
 import sys
+
+# Sidebar navigation
+st.sidebar.page_link("Home.py", label="🏠 Home")
+st.sidebar.page_link("pages/Dictionary.py", label="📚 Dictionary")
+st.sidebar.page_link("pages/Upload.py", label="📤 Upload")
+st.sidebar.page_link("pages/Reports.py", label="📊 Reports")
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
 from file_processor import process_single_file, process_uploaded_csv
 


### PR DESCRIPTION
- Implemented a fully custom sidebar with manual page links for Home, Dictionary, Upload, and Reports.
- Disabled Streamlit's default sidebar navigation via `config.toml`.
- Improved Home page content: added a clearer introduction, step-by-step getting started guide, and better layout.
- related issue: #33
- closes: #33
